### PR TITLE
Production dockerfile should build instead of serve

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -2,11 +2,11 @@ FROM node:23-alpine
 
 WORKDIR /blokmap-frontend
 
-COPY package*.json ./
+COPY package.json package-lock.json ./
 
 RUN npm install -g npm
 RUN npm install
 
 COPY . .
 
-CMD [ "npm", "run", "dev" ]
+CMD [ "npm", "run", "build" ]


### PR DESCRIPTION
The dockerfile for production was a replica of the development dockerfile, this is now fixed.